### PR TITLE
Move from traditional conditional compilation to runtime detection if CUDA is functional

### DIFF
--- a/src/finalize_global_grid.jl
+++ b/src/finalize_global_grid.jl
@@ -17,7 +17,6 @@ See also: [`init_global_grid`](@ref)
 """
 function finalize_global_grid(;finalize_MPI::Bool=true)
     check_initialized();
-    #TODO
     free_gather_buffer();
     free_update_halo_buffers();
     if (finalize_MPI)

--- a/src/select_device.jl
+++ b/src/select_device.jl
@@ -1,9 +1,7 @@
 export select_device
 
 import MPI
-@static if ENABLE_CUDA
-    using CUDA
-end
+using CUDA
 
 """
     select_device()
@@ -12,14 +10,10 @@ Select the device (GPU) corresponding to the node-local MPI rank and return its 
 """
 function select_device()
     check_initialized();
-    @static if ENABLE_CUDA
-        @assert CUDA.functional(true)
-        comm_l = MPI.Comm_split_type(comm(), MPI.MPI_COMM_TYPE_SHARED, me())
-    	if (MPI.Comm_size(comm_l) > length(CUDA.devices())) error("More processes have been launched per node than there are GPUs available."); end
-    	me_l = MPI.Comm_rank(comm_l)
-        CUDA.device!(me_l)
-        return me_l
-    else
-        error("Cannot select a GPU because ImplicitGlobalGrid was not precompiled for GPU usage (as CUDA was not functional).")
-    end
+    @assert CUDA.functional(true)
+    comm_l = MPI.Comm_split_type(comm(), MPI.MPI_COMM_TYPE_SHARED, me())
+	if (MPI.Comm_size(comm_l) > length(CUDA.devices())) error("More processes have been launched per node than there are GPUs available."); end
+	me_l = MPI.Comm_rank(comm_l)
+    CUDA.device!(me_l)
+    return me_l
 end

--- a/src/select_device.jl
+++ b/src/select_device.jl
@@ -9,11 +9,15 @@ using CUDA
 Select the device (GPU) corresponding to the node-local MPI rank and return its ID. This function only needs to be called when using nodes with more than one device.
 """
 function select_device()
-    check_initialized();
-    @assert CUDA.functional(true)
-    comm_l = MPI.Comm_split_type(comm(), MPI.MPI_COMM_TYPE_SHARED, me())
-	if (MPI.Comm_size(comm_l) > length(CUDA.devices())) error("More processes have been launched per node than there are GPUs available."); end
-	me_l = MPI.Comm_rank(comm_l)
-    CUDA.device!(me_l)
-    return me_l
+	if cuda_enabled()
+	    check_initialized();
+	    @assert CUDA.functional(true)
+	    comm_l = MPI.Comm_split_type(comm(), MPI.MPI_COMM_TYPE_SHARED, me())
+		if (MPI.Comm_size(comm_l) > length(CUDA.devices())) error("More processes have been launched per node than there are GPUs available."); end
+		me_l = MPI.Comm_rank(comm_l)
+	    CUDA.device!(me_l)
+	    return me_l
+	else
+		error("Cannot select a device because CUDA was detected not functional when the ImplicitGlobalGrid module was loaded.")
+	end
 end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -1,9 +1,7 @@
 export nx_g, ny_g, nz_g, x_g, y_g, z_g, tic, toc
 
 import MPI
-@static if ENABLE_CUDA
-    using CUDA
-end
+using CUDA
 
 
 macro nx_g()    esc(:( global_grid().nxyz_g[1] )) end

--- a/test/test_finalize_global_grid.jl
+++ b/test/test_finalize_global_grid.jl
@@ -7,7 +7,7 @@ import ImplicitGlobalGrid: @require
 
 @testset "$(basename(@__FILE__))" begin
     @testset "1. finalization of global grid and MPI" begin
-        init_global_grid(4, 4, 4, quiet=true);
+        init_global_grid(4, 4, 4, quiet=true); # NOTE: these tests can run with any number of processes.
         @require GG.grid_is_initialized()
         @require !MPI.Finalized()
         finalize_global_grid()

--- a/test/test_init_global_grid.jl
+++ b/test/test_init_global_grid.jl
@@ -5,7 +5,7 @@ import MPI
 import ImplicitGlobalGrid: @require
 
 
-## Test setup (NOTE: Testset "2. initialization including MPI" completes the test setup as it initializes MPI and must therefore mandatorily be at the 2nd position)
+## Test setup (NOTE: Testset "2. initialization including MPI" completes the test setup as it initializes MPI and must therefore mandatorily be at the 2nd position). NOTE: these tests require nprocs == 1.
 p0 = MPI.MPI_PROC_NULL
 nx = 4;
 ny = 4;

--- a/test/test_select_device.jl
+++ b/test/test_select_device.jl
@@ -3,17 +3,15 @@ push!(LOAD_PATH, "../src")
 using Test
 using ImplicitGlobalGrid; GG = ImplicitGlobalGrid
 import MPI
+using CUDA
 import ImplicitGlobalGrid: @require
 
-test_gpu = GG.ENABLE_CUDA
-if test_gpu
-	using CUDA
-	@assert CUDA.functional(true)
-end
+test_gpu = CUDA.functional()
+
 
 ## Test setup
 MPI.Init();
-nprocs = MPI.Comm_size(MPI.COMM_WORLD);
+nprocs = MPI.Comm_size(MPI.COMM_WORLD); # NOTE: these tests can run with any number of processes.
 
 @testset "$(basename(@__FILE__)) (processes: $nprocs)" begin
     @testset "1. select_device" begin
@@ -22,7 +20,7 @@ nprocs = MPI.Comm_size(MPI.COMM_WORLD);
             gpu_id = select_device();
             @test gpu_id < length(CUDA.devices())
         else
-            @test_throws ErrorException select_device()
+            @test_throws CUDA.CuError select_device()
         end
         finalize_global_grid(finalize_MPI=false);
     end;

--- a/test/test_select_device.jl
+++ b/test/test_select_device.jl
@@ -20,7 +20,7 @@ nprocs = MPI.Comm_size(MPI.COMM_WORLD); # NOTE: these tests can run with any num
             gpu_id = select_device();
             @test gpu_id < length(CUDA.devices())
         else
-            @test_throws CUDA.CuError select_device()
+            @test_throws ErrorException select_device()
         end
         finalize_global_grid(finalize_MPI=false);
     end;

--- a/test/test_tools.jl
+++ b/test/test_tools.jl
@@ -9,7 +9,7 @@ macro coords(i) :(GG.global_grid().coords[$i]) end
 ## Test setup
 MPI.Init();
 nprocs = MPI.Comm_size(MPI.COMM_WORLD);
-@require nprocs == 1  # NOTE: these tests requires nprocs == 1.
+@require nprocs == 1  # NOTE: these tests require nprocs == 1.
 
 @testset "$(basename(@__FILE__))" begin
     @testset "1. *_g functions" begin

--- a/test/test_tools.jl
+++ b/test/test_tools.jl
@@ -9,7 +9,7 @@ macro coords(i) :(GG.global_grid().coords[$i]) end
 ## Test setup
 MPI.Init();
 nprocs = MPI.Comm_size(MPI.COMM_WORLD);
-@require nprocs == 1  # This test requires nprocs to be 1.
+@require nprocs == 1  # NOTE: these tests requires nprocs == 1.
 
 @testset "$(basename(@__FILE__))" begin
     @testset "1. *_g functions" begin

--- a/test/test_update_halo.jl
+++ b/test/test_update_halo.jl
@@ -6,12 +6,12 @@ push!(LOAD_PATH, "../src")
 using Test
 using ImplicitGlobalGrid; GG = ImplicitGlobalGrid
 import MPI
+using CUDA
 import ImplicitGlobalGrid: @require, longnameof
 
-test_gpu = GG.ENABLE_CUDA
+test_gpu = CUDA.functional()
+
 if test_gpu
-	using CUDA
-	@assert CUDA.functional(true)
 	global cuzeros = CUDA.zeros
 	global allocators = [zeros, cuzeros]
 	global ArrayConstructors = [Array, CuArray]
@@ -24,7 +24,7 @@ end
 
 ## Test setup
 MPI.Init();
-nprocs = MPI.Comm_size(MPI.COMM_WORLD);
+nprocs = MPI.Comm_size(MPI.COMM_WORLD); # NOTE: these tests can run with any number of processes.
 ndims_mpi = GG.NDIMS_MPI;
 nneighbors_per_dim = GG.NNEIGHBORS_PER_DIM; # Should be 2 (one left and one right neighbor).
 nx = 7;


### PR DESCRIPTION
When ImplicitGlobalGrid was designed, the only possibility to support CPU without requiring a working CUDA stack was with traditional conditional compilation. The Julia community has now established a more convenient way to handle multiple backend packages: such packages allow to compile without, e.g., a GPU and do not fail at `using`, but only when actual operations cannot be performed. Moreover, CUDA.jl provides the function `CUDA.functional` to check if CUDA is usable.

This PR removes traditional conditional compilation (with macros acting at precompilation time) and introduces checking if CUDA is functional at module load time. If CUDA is not functional at module load time, but the user passes a `CuArray` to `update_halo!` (if that may even ever happen), it will fail.