### PR TITLE
Give error in init_global_grid if the global grid was already initialized

### DIFF
--- a/src/ImplicitGlobalGrid.jl
+++ b/src/ImplicitGlobalGrid.jl
@@ -24,7 +24,7 @@ https://github.com/eth-cscs/ImplicitGlobalGrid.jl
 To see a description of a function type `?<functionname>`.
 
 !!! note "Performance note"
-    If the system supports CUDA-aware MPI, it may be activated for ImplicitGlobalGrid by setting the following environment variable (at latest before the first call to `init_global_grid`):
+    If the system supports CUDA-aware MPI, it may be activated for ImplicitGlobalGrid by setting the following environment variable (at latest before the call to `init_global_grid`):
     ```shell
     shell> export IGG_CUDAAWARE_MPI=1
     ```

--- a/src/init_global_grid.jl
+++ b/src/init_global_grid.jl
@@ -39,6 +39,7 @@ Initialize a Cartesian grid of MPI processes (and also MPI itself by default) de
 See also: [`finalize_global_grid`](@ref)
 """
 function init_global_grid(nx::Integer, ny::Integer, nz::Integer; dimx::Integer=0, dimy::Integer=0, dimz::Integer=0, periodx::Integer=0, periody::Integer=0, periodz::Integer=0, overlapx::Integer=2, overlapy::Integer=2, overlapz::Integer=2, disp::Integer=1, reorder::Integer=1, comm::MPI.Comm=MPI.COMM_WORLD, init_MPI::Bool=true, quiet::Bool=false)
+    if grid_is_initialized() error("The global grid has already been initialized.") end
     nxyz              = [nx, ny, nz];
     dims              = [dimx, dimy, dimz];
     periods           = [periodx, periody, periodz];

--- a/test/test_init_global_grid.jl
+++ b/test/test_init_global_grid.jl
@@ -23,6 +23,7 @@ nz = 1;
         @testset "initialized" begin
             @test GG.grid_is_initialized()
             @test MPI.Initialized()
+            @test_throws ErrorException("The global grid has already been initialized.") init_global_grid(nx, ny, nz, quiet=true, init_MPI=false);  # Error: IGG already initialised
         end;
         @testset "return values" begin
             @test me     == 0
@@ -95,8 +96,8 @@ nz = 1;
         nz = 4;
         @test_throws ErrorException init_global_grid(1, ny, nz, quiet=true, init_MPI=false);                         # Error: nx==1.
         @test_throws ErrorException init_global_grid(nx, 1, nz, quiet=true, init_MPI=false);                         # Error: ny==1, while nz>1.
-        @test_throws ErrorException init_global_grid(nx, ny, 1, dimz=3, quiet=true, init_MPI=false);                # Error: dimz>1 while nz==1.
-        @test_throws ErrorException init_global_grid(nx, ny, 1, periodz=1, quiet=true, init_MPI=false);             # Error: periodz==1 while nz==1.
+        @test_throws ErrorException init_global_grid(nx, ny, 1, dimz=3, quiet=true, init_MPI=false);                 # Error: dimz>1 while nz==1.
+        @test_throws ErrorException init_global_grid(nx, ny, 1, periodz=1, quiet=true, init_MPI=false);              # Error: periodz==1 while nz==1.
         @test_throws ErrorException init_global_grid(nx, ny, nz, periody=1, overlapy=3, quiet=true, init_MPI=false); # Error: periody==1 while ny<2*overlapy-1 (4<5).
         @test_throws ErrorException init_global_grid(nx, ny, nz, quiet=true);                                        # Error: MPI already initialized
     end;

--- a/test/test_init_global_grid.jl
+++ b/test/test_init_global_grid.jl
@@ -23,7 +23,6 @@ nz = 1;
         @testset "initialized" begin
             @test GG.grid_is_initialized()
             @test MPI.Initialized()
-            @test_throws ErrorException("The global grid has already been initialized.") init_global_grid(nx, ny, nz, quiet=true, init_MPI=false);  # Error: IGG already initialised
         end;
         @testset "return values" begin
             @test me     == 0
@@ -91,6 +90,8 @@ nz = 1;
     end;
 
     @testset "6. post-MPI_Init-exceptions" begin
+        @require MPI.Initialized()
+        @require !GG.grid_is_initialized()
         nx = 4;
         ny = 4;
         nz = 4;
@@ -100,6 +101,12 @@ nz = 1;
         @test_throws ErrorException init_global_grid(nx, ny, 1, periodz=1, quiet=true, init_MPI=false);              # Error: periodz==1 while nz==1.
         @test_throws ErrorException init_global_grid(nx, ny, nz, periody=1, overlapy=3, quiet=true, init_MPI=false); # Error: periody==1 while ny<2*overlapy-1 (4<5).
         @test_throws ErrorException init_global_grid(nx, ny, nz, quiet=true);                                        # Error: MPI already initialized
+        @testset "already initialized exception" begin
+            init_global_grid(nx, ny, nz, quiet=true, init_MPI=false);
+            @require GG.grid_is_initialized()
+            @test_throws ErrorException init_global_grid(nx, ny, nz, quiet=true, init_MPI=false);  # Error: IGG already initialised
+            finalize_global_grid(finalize_MPI=false);
+        end;
     end;
 end;
 


### PR DESCRIPTION
- Fix docstring
- Add error check if global grid is already initialised and corresponding unit test