### PR TITLE
Enable device_type to be none

### DIFF
--- a/src/shared.jl
+++ b/src/shared.jl
@@ -30,6 +30,7 @@ const NDIMS_MPI = 3                    # Internally, we set the number of dimens
 const NNEIGHBORS_PER_DIM = 2           # Number of neighbors per dimension (left neighbor + right neighbor).
 const GG_ALLOC_GRANULARITY = 32        # Internal buffers are allocated with a granulariy of GG_ALLOC_GRANULARITY elements in order to ensure correct reinterpretation when used for different types and to reduce amount of re-allocations.
 const GG_THREADCOPY_THRESHOLD = 32768  # When LoopVectorization is deactivated, then the GG_THREADCOPY_THRESHOLD defines the size in bytes upon which memory copy is performed with multiple threads.
+const DEVICE_TYPE_NONE = "none"
 const DEVICE_TYPE_AUTO = "auto"
 const DEVICE_TYPE_CUDA = "CUDA"
 const DEVICE_TYPE_AMDGPU = "AMDGPU"

--- a/test/test_select_device.jl
+++ b/test/test_select_device.jl
@@ -16,20 +16,57 @@ nprocs = MPI.Comm_size(MPI.COMM_WORLD); # NOTE: these tests can run with any num
 
 @testset "$(basename(@__FILE__)) (processes: $nprocs)" begin
     @testset "1. select_device" begin
-        @static if test_cuda
-            me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="CUDA");
-            gpu_id = select_device();
-            @test gpu_id < length(CUDA.devices())
-            finalize_global_grid(finalize_MPI=false);
+        @static if test_cuda && !test_amdgpu
+            @testset "\"CUDA\"" begin
+                me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="CUDA");
+                gpu_id = select_device();
+                @test gpu_id < length(CUDA.devices())
+                finalize_global_grid(finalize_MPI=false);
+            end;
+            @testset "\"auto\"" begin
+                me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="auto");
+                gpu_id = select_device();
+                @test gpu_id < length(CUDA.devices())
+                finalize_global_grid(finalize_MPI=false);
+            end;
         end
-        @static if test_amdgpu
-            me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="AMDGPU");
-            gpu_id = select_device();
-            @test gpu_id < length(AMDGPU.devices())
-            finalize_global_grid(finalize_MPI=false);
+        @static if test_amdgpu && !test_cuda
+            @testset "\"AMDGPU\"" begin
+                me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="AMDGPU");
+                gpu_id = select_device();
+                @test gpu_id < length(AMDGPU.devices())
+                finalize_global_grid(finalize_MPI=false);
+            end;
+            @testset "\"auto\"" begin
+                me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="auto");
+                gpu_id = select_device();
+                @test gpu_id < length(AMDGPU.devices())
+                finalize_global_grid(finalize_MPI=false);
+            end;
         end
-        @static if !(test_cuda || test_amdgpu)
-            me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false);
+        @static if !(test_cuda || test_amdgpu) || (test_cuda && test_amdgpu)
+            @testset "\"auto\"" begin
+                me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="auto");
+                @test_throws ErrorException select_device()
+                finalize_global_grid(finalize_MPI=false);
+            end;
+        end
+        @static if !test_cuda
+            @testset "\"CUDA\"" begin
+                me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="CUDA");
+                @test_throws ErrorException select_device()
+                finalize_global_grid(finalize_MPI=false);
+            end;
+        end
+        @static if !test_amdgpu
+            @testset "\"AMDGPU\"" begin
+                me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="AMDGPU");
+                @test_throws ErrorException select_device()
+                finalize_global_grid(finalize_MPI=false);
+            end;
+        end
+        @testset "\"none\"" begin
+            me, = init_global_grid(3, 4, 5; quiet=true, init_MPI=false, device_type="none");
             @test_throws ErrorException select_device()
             finalize_global_grid(finalize_MPI=false);
         end


### PR DESCRIPTION
This makes the use case of using CPUs only on a system having also GPUs more clear.