### PR TITLE
Replace LoopVectorization extension with Polyester extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,17 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 
 [extensions]
-ImplicitGlobalGrid_LoopVectorizationExt = "LoopVectorization"
+ImplicitGlobalGrid_PolyesterExt = "Polyester"
 ImplicitGlobalGrid_AMDGPUExt = "AMDGPU"
 ImplicitGlobalGrid_CUDAExt = "CUDA"
 
 [compat]
 AMDGPU = "0.5, 0.6, 0.7, 0.8"
 CUDA = "1, ~3.1, ~3.2, ~3.3, ~3.7.1, ~3.8, ~3.9, ~3.10, ~3.11, ~3.12, ~3.13, 4, 5"
-LoopVectorization = "0.12"
+Polyester = "0.7"
 MPI = "0.20"
 julia = "1.9"
 
@@ -29,4 +29,4 @@ MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MPIPreferences", "AMDGPU", "CUDA", "LoopVectorization"]
+test = ["Test", "MPIPreferences", "AMDGPU", "CUDA", "Polyester"]

--- a/ext/ImplicitGlobalGrid_LoopVectorizationExt.jl
+++ b/ext/ImplicitGlobalGrid_LoopVectorizationExt.jl
@@ -1,3 +1,0 @@
-module ImplicitGlobalGrid_LoopVectorizationExt
-    include(joinpath(@__DIR__, "..", "src", "LoopVectorizationExt", "memcopy_LV.jl"))
-end

--- a/ext/ImplicitGlobalGrid_PolyesterExt.jl
+++ b/ext/ImplicitGlobalGrid_PolyesterExt.jl
@@ -1,0 +1,3 @@
+module ImplicitGlobalGrid_PolyesterExt
+    include(joinpath(@__DIR__, "..", "src", "PolyesterExt", "memcopy_polyester.jl"))
+end

--- a/src/ImplicitGlobalGrid.jl
+++ b/src/ImplicitGlobalGrid.jl
@@ -48,7 +48,7 @@ include("shared.jl")
 include("defaults_shared.jl")
 include(joinpath("AMDGPUExt", "defaults.jl"))
 include(joinpath("CUDAExt", "defaults.jl"))
-include(joinpath("LoopVectorizationExt", "memcopy_LV_default.jl"))
+include(joinpath("PolyesterExt", "memcopy_polyester_default.jl"))
 
 ## Alphabetical include of files
 include("finalize_global_grid.jl")

--- a/src/LoopVectorizationExt/memcopy_LV.jl
+++ b/src/LoopVectorizationExt/memcopy_LV.jl
@@ -1,9 +1,0 @@
-import ImplicitGlobalGrid
-import ImplicitGlobalGrid: GGNumber
-using LoopVectorization
-
-function ImplicitGlobalGrid.memcopy_loopvect!(dst::AbstractArray{T}, src::AbstractArray{T}) where T <: GGNumber
-    @tturbo for i ∈ eachindex(dst, src)  # NOTE: tturbo will use maximally Threads.nthreads() threads. Set the number of threads e.g. as: export JULIA_NUM_THREADS=12. NOTE: tturbo fails if src_flat and dst_flat are used due to an issue in ArrayInterface : https://github.com/JuliaArrays/ArrayInterface.jl/issues/228
-        @inbounds dst[i] = src[i]        # NOTE: We fix here exceptionally the use of @inbounds (currently anyways done by LoopVectorization) as this copy between two flat vectors (which must have the right length) is considered safe.
-    end
-end

--- a/src/LoopVectorizationExt/memcopy_LV_default.jl
+++ b/src/LoopVectorizationExt/memcopy_LV_default.jl
@@ -1,3 +1,0 @@
-const ERRMSG_EXTENSION_NOT_LOADED = "AD: the LoopVectorization extension was not loaded. Make sure to import LoopVectorization before ImplicitGlobalGrid."
-
-memcopy_loopvect!(args...) = @NotLoadedError(ERRMSG_EXTENSION_NOT_LOADED)

--- a/src/PolyesterExt/memcopy_polyester.jl
+++ b/src/PolyesterExt/memcopy_polyester.jl
@@ -1,0 +1,10 @@
+import ImplicitGlobalGrid
+import ImplicitGlobalGrid: GGNumber
+using Polyester
+
+function ImplicitGlobalGrid.memcopy_polyester!(dst::AbstractArray{T}, src::AbstractArray{T}) where T <: GGNumber
+    @info "Using PolyesterExt for memory copy"
+    @batch for i ∈ eachindex(dst, src)  # NOTE: @batch will use maximally Threads.nthreads() threads / #cores threads. Set the number of threads e.g. as: export JULIA_NUM_THREADS=12. NOTE on previous implementation with LoopVectorization: tturbo fails if src_flat and dst_flat are used due to an issue in ArrayInterface : https://github.com/JuliaArrays/ArrayInterface.jl/issues/228 TODO: once the package has matured check again if there is any benefit with: per=core stride=true
+        @inbounds dst[i] = src[i]       # NOTE: We fix here exceptionally the use of @inbounds as this copy between two flat vectors (which must have the right length) is considered safe.
+    end
+end

--- a/src/PolyesterExt/memcopy_polyester.jl
+++ b/src/PolyesterExt/memcopy_polyester.jl
@@ -3,7 +3,6 @@ import ImplicitGlobalGrid: GGNumber
 using Polyester
 
 function ImplicitGlobalGrid.memcopy_polyester!(dst::AbstractArray{T}, src::AbstractArray{T}) where T <: GGNumber
-    @info "Using PolyesterExt for memory copy"
     @batch for i ∈ eachindex(dst, src)  # NOTE: @batch will use maximally Threads.nthreads() threads / #cores threads. Set the number of threads e.g. as: export JULIA_NUM_THREADS=12. NOTE on previous implementation with LoopVectorization: tturbo fails if src_flat and dst_flat are used due to an issue in ArrayInterface : https://github.com/JuliaArrays/ArrayInterface.jl/issues/228 TODO: once the package has matured check again if there is any benefit with: per=core stride=true
         @inbounds dst[i] = src[i]       # NOTE: We fix here exceptionally the use of @inbounds as this copy between two flat vectors (which must have the right length) is considered safe.
     end

--- a/src/PolyesterExt/memcopy_polyester_default.jl
+++ b/src/PolyesterExt/memcopy_polyester_default.jl
@@ -1,0 +1,3 @@
+const ERRMSG_EXTENSION_NOT_LOADED = "PolyesterExt: the Polyester extension was not loaded. Make sure to import Polyester before ImplicitGlobalGrid."
+
+memcopy_polyester!(args...) = @NotLoadedError(ERRMSG_EXTENSION_NOT_LOADED)

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -28,7 +28,7 @@ end
 const NDIMS_MPI = 3                    # Internally, we set the number of dimensions always to 3 for calls to MPI. This ensures a fixed size for MPI coords, neigbors, etc and in general a simple, easy to read code.
 const NNEIGHBORS_PER_DIM = 2           # Number of neighbors per dimension (left neighbor + right neighbor).
 const GG_ALLOC_GRANULARITY = 32        # Internal buffers are allocated with a granulariy of GG_ALLOC_GRANULARITY elements in order to ensure correct reinterpretation when used for different types and to reduce amount of re-allocations.
-const GG_THREADCOPY_THRESHOLD = 32768  # When LoopVectorization is deactivated, then the GG_THREADCOPY_THRESHOLD defines the size in bytes upon which memory copy is performed with multiple threads.
+const GG_THREADCOPY_THRESHOLD = 32768  # When Polyester is deactivated, then the GG_THREADCOPY_THRESHOLD defines the size in bytes upon which memory copy is performed with multiple threads.
 const DEVICE_TYPE_NONE = "none"
 const DEVICE_TYPE_AUTO = "auto"
 const DEVICE_TYPE_CUDA = "CUDA"
@@ -66,7 +66,7 @@ struct GlobalGrid
     amdgpu_enabled::Bool
     cudaaware_MPI::Vector{Bool}
     amdgpuaware_MPI::Vector{Bool}
-    loopvectorization::Vector{Bool}
+    use_polyester::Vector{Bool}
     quiet::Bool
 end
 const GLOBAL_GRID_NULL = GlobalGrid(GGInt[-1,-1,-1], GGInt[-1,-1,-1], GGInt[-1,-1,-1], GGInt[-1,-1,-1], GGInt[-1,-1,-1], -1, -1, GGInt[-1,-1,-1], GGInt[-1 -1 -1; -1 -1 -1], GGInt[-1,-1,-1], -1, -1, MPI.COMM_NULL, false, false, [false,false,false], [false,false,false], [false,false,false], false)
@@ -108,8 +108,8 @@ cudaaware_MPI()                        = global_grid().cudaaware_MPI
 cudaaware_MPI(dim::Integer)            = global_grid().cudaaware_MPI[dim]
 amdgpuaware_MPI()                      = global_grid().amdgpuaware_MPI
 amdgpuaware_MPI(dim::Integer)          = global_grid().amdgpuaware_MPI[dim]
-loopvectorization()                    = global_grid().loopvectorization
-loopvectorization(dim::Integer)        = global_grid().loopvectorization[dim]
+use_polyester()                        = global_grid().use_polyester
+use_polyester(dim::Integer)            = global_grid().use_polyester[dim]
 has_neighbor(n::Integer, dim::Integer) = neighbor(n, dim) != MPI.PROC_NULL
 any_array(fields::GGField...)          = any([is_array(A.A) for A in fields])
 any_cuarray(fields::GGField...)        = any([is_cuarray(A.A) for A in fields])

--- a/src/update_halo.jl
+++ b/src/update_halo.jl
@@ -33,7 +33,7 @@ function update_halo!(A::Union{GGArray, GGField, GGFieldConvertible}...)
     _update_halo!(fields...);  # Assignment of A to fields in the internal function _update_halo!() as vararg A can consist of multiple fields; A will be used for a single field in the following (The args of update_halo! must however be "A..." for maximal simplicity and elegance for the user).
     return nothing
 end
-
+#
 function _update_halo!(fields::GGField...)
     if (!cuda_enabled() && !amdgpu_enabled() && !all_arrays(fields...)) error("not all arrays are CPU arrays, but no GPU extension is loaded.") end #NOTE: in the following, it is only required to check for `cuda_enabled()`/`amdgpu_enabled()` when the context does not imply `any_cuarray(fields...)` or `is_cuarray(A)` or the corresponding for AMDGPU. # NOTE: the case where only one of the two extensions are loaded, but an array dad would be for the other extension is passed is very unlikely and therefore not explicitly checked here (but could be added later).
     allocate_bufs(fields...);
@@ -302,14 +302,14 @@ function write_h2h!(sendbuf::AbstractArray{T}, A::Array{T}, sendranges::Array{Un
     ix = (length(sendranges[1])==1) ? sendranges[1][1] : sendranges[1];
     iy = (length(sendranges[2])==1) ? sendranges[2][1] : sendranges[2];
     iz = (length(sendranges[3])==1) ? sendranges[3][1] : sendranges[3];
-    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3)) memcopy!(view(sendbuf, 1, :, :), view(A,ix, :, :), loopvectorization(dim));
-    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(sendbuf, 1, 1, :), view(A,ix,iy, :), loopvectorization(dim));
-    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(sendbuf, 1, :, 1), view(A,ix, :,iz), loopvectorization(dim));
-    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1    ) memcopy!(view(sendbuf, 1, 1, 1), view(A,ix,iy,iz), loopvectorization(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(sendbuf, :, 1, :), view(A, :,iy, :), loopvectorization(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1    ) memcopy!(view(sendbuf, :, 1, 1), view(A, :,iy,iz), loopvectorization(dim));
-    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(sendbuf, :, :, 1), view(A, :, :,iz), loopvectorization(dim));
-    else                                                                 memcopy!(sendbuf, view(A,sendranges...), loopvectorization(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
+    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3)) memcopy!(view(sendbuf, 1, :, :), view(A,ix, :, :), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(sendbuf, 1, 1, :), view(A,ix,iy, :), use_polyester(dim));
+    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(sendbuf, 1, :, 1), view(A,ix, :,iz), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1    ) memcopy!(view(sendbuf, 1, 1, 1), view(A,ix,iy,iz), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(sendbuf, :, 1, :), view(A, :,iy, :), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1    ) memcopy!(view(sendbuf, :, 1, 1), view(A, :,iy,iz), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(sendbuf, :, :, 1), view(A, :, :,iz), use_polyester(dim));
+    else                                                                 memcopy!(sendbuf, view(A,sendranges...), use_polyester(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
     end
 end
 
@@ -318,14 +318,14 @@ function read_h2h!(recvbuf::AbstractArray{T}, A::Array{T}, recvranges::Array{Uni
     ix = (length(recvranges[1])==1) ? recvranges[1][1] : recvranges[1];
     iy = (length(recvranges[2])==1) ? recvranges[2][1] : recvranges[2];
     iz = (length(recvranges[3])==1) ? recvranges[3][1] : recvranges[3];
-    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3)) memcopy!(view(A,ix, :, :), view(recvbuf, 1, :, :), loopvectorization(dim));
-    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(A,ix,iy, :), view(recvbuf, 1, 1, :), loopvectorization(dim));
-    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(A,ix, :,iz), view(recvbuf, 1, :, 1), loopvectorization(dim));
-    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1    ) memcopy!(view(A,ix,iy,iz), view(recvbuf, 1, 1, 1), loopvectorization(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(A, :,iy, :), view(recvbuf, :, 1, :), loopvectorization(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1    ) memcopy!(view(A, :,iy,iz), view(recvbuf, :, 1, 1), loopvectorization(dim));
-    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(A, :, :,iz), view(recvbuf, :, :, 1), loopvectorization(dim));
-    else                                                                 memcopy!(view(A,recvranges...), recvbuf, loopvectorization(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
+    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3)) memcopy!(view(A,ix, :, :), view(recvbuf, 1, :, :), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(A,ix,iy, :), view(recvbuf, 1, 1, :), use_polyester(dim));
+    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(A,ix, :,iz), view(recvbuf, 1, :, 1), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1    ) memcopy!(view(A,ix,iy,iz), view(recvbuf, 1, 1, 1), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(A, :,iy, :), view(recvbuf, :, 1, :), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1    ) memcopy!(view(A, :,iy,iz), view(recvbuf, :, 1, 1), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(A, :, :,iz), view(recvbuf, :, :, 1), use_polyester(dim));
+    else                                                                 memcopy!(view(A,recvranges...), recvbuf, use_polyester(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
     end
 end
 
@@ -370,17 +370,17 @@ function sendrecv_halo_local(n::Integer, dim::Integer, F::GGField, i::Integer)
             end
         else
             if n == 1
-                memcopy!(recvbuf_flat(2,dim,i,F), sendbuf_flat(1,dim,i,F), loopvectorization(dim));
+                memcopy!(recvbuf_flat(2,dim,i,F), sendbuf_flat(1,dim,i,F), use_polyester(dim));
             elseif n == 2
-                memcopy!(recvbuf_flat(1,dim,i,F), sendbuf_flat(2,dim,i,F), loopvectorization(dim));
+                memcopy!(recvbuf_flat(1,dim,i,F), sendbuf_flat(2,dim,i,F), use_polyester(dim));
             end
         end
     end
 end
 
-function memcopy!(dst::AbstractArray{T}, src::AbstractArray{T}, loopvectorization::Bool) where T <: GGNumber
-    if loopvectorization && nthreads() > 1 && length(src) > 1 && !(T <: Complex)  # NOTE: LoopVectorization does not yet support Complex numbers and copy reinterpreted arrays leads to bad performance.
-        memcopy_loopvect!(dst, src)
+function memcopy!(dst::AbstractArray{T}, src::AbstractArray{T}, use_polyester::Bool) where T <: GGNumber
+    if use_polyester && nthreads() > 1 && length(src) > 1 && !(T <: Complex)  # NOTE: Polyester does not yet support Complex numbers and copy reinterpreted arrays leads to bad performance.
+        memcopy_polyester!(dst, src)
     else
         dst_flat = view(dst,:)
         src_flat = view(src,:)

--- a/src/update_halo.jl
+++ b/src/update_halo.jl
@@ -302,14 +302,14 @@ function write_h2h!(sendbuf::AbstractArray{T}, A::Array{T}, sendranges::Array{Un
     ix = (length(sendranges[1])==1) ? sendranges[1][1] : sendranges[1];
     iy = (length(sendranges[2])==1) ? sendranges[2][1] : sendranges[2];
     iz = (length(sendranges[3])==1) ? sendranges[3][1] : sendranges[3];
-    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3)) memcopy!(view(sendbuf, 1, :, :), view(A,ix, :, :), use_polyester(dim));
-    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(sendbuf, 1, 1, :), view(A,ix,iy, :), use_polyester(dim));
-    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(sendbuf, 1, :, 1), view(A,ix, :,iz), use_polyester(dim));
-    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1    ) memcopy!(view(sendbuf, 1, 1, 1), view(A,ix,iy,iz), use_polyester(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(sendbuf, :, 1, :), view(A, :,iy, :), use_polyester(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1    ) memcopy!(view(sendbuf, :, 1, 1), view(A, :,iy,iz), use_polyester(dim));
-    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(sendbuf, :, :, 1), view(A, :, :,iz), use_polyester(dim));
-    else                                                                 memcopy!(sendbuf, view(A,sendranges...), use_polyester(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
+    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3) && !use_polyester(dim)) memcopy!(view(sendbuf, 1, :, :), view(A,ix, :, :), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3) && !use_polyester(dim)) memcopy!(view(sendbuf, 1, 1, :), view(A,ix,iy, :), use_polyester(dim));
+    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1     && !use_polyester(dim)) memcopy!(view(sendbuf, 1, :, 1), view(A,ix, :,iz), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1     && !use_polyester(dim)) memcopy!(view(sendbuf, 1, 1, 1), view(A,ix,iy,iz), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)                       ) memcopy!(view(sendbuf, :, 1, :), view(A, :,iy, :), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1                           ) memcopy!(view(sendbuf, :, 1, 1), view(A, :,iy,iz), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1                           ) memcopy!(view(sendbuf, :, :, 1), view(A, :, :,iz), use_polyester(dim));
+    else                                                                                        memcopy!(sendbuf, view(A,sendranges...), use_polyester(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
     end
 end
 
@@ -318,14 +318,14 @@ function read_h2h!(recvbuf::AbstractArray{T}, A::Array{T}, recvranges::Array{Uni
     ix = (length(recvranges[1])==1) ? recvranges[1][1] : recvranges[1];
     iy = (length(recvranges[2])==1) ? recvranges[2][1] : recvranges[2];
     iz = (length(recvranges[3])==1) ? recvranges[3][1] : recvranges[3];
-    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3)) memcopy!(view(A,ix, :, :), view(recvbuf, 1, :, :), use_polyester(dim));
-    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(A,ix,iy, :), view(recvbuf, 1, 1, :), use_polyester(dim));
-    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(A,ix, :,iz), view(recvbuf, 1, :, 1), use_polyester(dim));
-    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1    ) memcopy!(view(A,ix,iy,iz), view(recvbuf, 1, 1, 1), use_polyester(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)) memcopy!(view(A, :,iy, :), view(recvbuf, :, 1, :), use_polyester(dim));
-    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1    ) memcopy!(view(A, :,iy,iz), view(recvbuf, :, 1, 1), use_polyester(dim));
-    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1    ) memcopy!(view(A, :, :,iz), view(recvbuf, :, :, 1), use_polyester(dim));
-    else                                                                 memcopy!(view(A,recvranges...), recvbuf, use_polyester(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
+    if     (length(ix)==1     && iy == 1:size(A,2) && iz == 1:size(A,3) && !use_polyester(dim)) memcopy!(view(A,ix, :, :), view(recvbuf, 1, :, :), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && iz == 1:size(A,3) && !use_polyester(dim)) memcopy!(view(A,ix,iy, :), view(recvbuf, 1, 1, :), use_polyester(dim));
+    elseif (length(ix)==1     && iy == 1:size(A,2) && length(iz)==1     && !use_polyester(dim)) memcopy!(view(A,ix, :,iz), view(recvbuf, 1, :, 1), use_polyester(dim));
+    elseif (length(ix)==1     && length(iy)==1     && length(iz)==1     && !use_polyester(dim)) memcopy!(view(A,ix,iy,iz), view(recvbuf, 1, 1, 1), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && iz == 1:size(A,3)                       ) memcopy!(view(A, :,iy, :), view(recvbuf, :, 1, :), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && length(iy)==1     && length(iz)==1                           ) memcopy!(view(A, :,iy,iz), view(recvbuf, :, 1, 1), use_polyester(dim));
+    elseif (ix == 1:size(A,1) && iy == 1:size(A,2) && length(iz)==1                           ) memcopy!(view(A, :, :,iz), view(recvbuf, :, :, 1), use_polyester(dim));
+    else                                                                                        memcopy!(view(A,recvranges...), recvbuf, use_polyester(dim)); # This general case is slower than the optimised cases above (the result would be the same, of course).
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ function runtests()
             continue
         end
         try
-            run(`$exename -O3 --startup-file=no --check-bounds=no $(joinpath(testdir, f))`)
+            run(`$exename -O3 --startup-file=no $(joinpath(testdir, f))`)
         catch ex
             nfail += 1
         end

--- a/test/test_update_halo.jl
+++ b/test/test_update_halo.jl
@@ -4,7 +4,7 @@
 
 push!(LOAD_PATH, "../src")
 using Test
-import MPI, LoopVectorization
+import MPI, Polyester
 using CUDA, AMDGPU
 using ImplicitGlobalGrid; GG = ImplicitGlobalGrid
 import ImplicitGlobalGrid: @require, longnameof


### PR DESCRIPTION
Background: The Polyester package is better suited for the tasks at hand in ImplicitGlobalGrid. In particular, it can be beneficial for small problems. Furthermore, LoopVectorization is on the path to get deprecated.