### PR TITLE
AMDGPU Extension - Update write/read async device to host and viceversa

### DIFF
--- a/src/AMDGPUExt/update_halo.jl
+++ b/src/AMDGPUExt/update_halo.jl
@@ -224,7 +224,7 @@ function ImplicitGlobalGrid.write_d2h_async!(sendbuf::AbstractArray{T}, A::AnyRO
     buf_view = reshape(sendbuf, Tuple(length.(sendranges)))
     AMDGPU.Mem.unsafe_copy3d!(
         pointer(sendbuf), AMDGPU.Mem.HostBuffer,
-        pointer(A), typeof(A.buf),
+        pointer(A), AMDGPU.Mem.HIPBuffer,
         length(sendranges[1]), length(sendranges[2]), length(sendranges[3]);
         srcPos=(sendranges[1][1], sendranges[2][1], sendranges[3][1]),
         dstPitch=sizeof(T) * size(buf_view, 1), dstHeight=size(buf_view, 2),
@@ -238,7 +238,7 @@ end
 function ImplicitGlobalGrid.read_h2d_async!(recvbuf::AbstractArray{T}, A::AnyROCArray{T}, recvranges::Array{UnitRange{T2},1}, rocstream::AMDGPU.HIPStream) where T <: GGNumber where T2 <: Integer
     buf_view = reshape(recvbuf, Tuple(length.(recvranges)))
     AMDGPU.Mem.unsafe_copy3d!(
-        pointer(A), typeof(A.buf),
+        pointer(A), AMDGPU.Mem.HIPBuffer,
         pointer(recvbuf), AMDGPU.Mem.HostBuffer,
         length(recvranges[1]), length(recvranges[2]), length(recvranges[3]);
         dstPos=(recvranges[1][1], recvranges[2][1], recvranges[3][1]),


### PR DESCRIPTION
AMDGPU.jl does not recognise the AnyROCArray as device arrays, as a result it cannot choose the memcopy kind to send to HIP and an error is thrown.

To solve it, given that the targeted methods are designed specifically for host to device transfers, we can write HIPBuffer as the type of the device array, therefore AMDGPU.jl can identify and send to HIP the correct kind of memcopy call.

PD: I would uncomment and try the test cases as well, but I'm in a hurry and I can't execute them properly (I'll talk to @omlins about it) so I prefer to not touch them yet. I did my own test to see if the memory was being copied just in case.