### PR TITLE
Re-enable async copy for AMDGPU backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         version:
           - '1.9' # Minimum version supporting extensions
+          - '1.10' # Current LTS
           - '1'   # Latest stable 1.x release of Julia
           # - 'nightly'
         os:
@@ -30,12 +31,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -48,7 +49,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
   # docs:


### PR DESCRIPTION
Fixes #63 while reactivating the async h2d and d2h r/w. Supersedes #105 as includes the `HIPBuffer` type fix.