### PR TITLE
Group GitHub Actions dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,15 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    groups:
+      # Group all GitHub Actions PRs into a single PR:
+      all-github-actions:
+        patterns:
+          - "*"
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
This will group GitHub Actions deps updates in a single PR & branch