### PR TITLE
Fix slow CPU halo update for the middle (y) decomposed dimension

### DIFF
--- a/src/update_halo.jl
+++ b/src/update_halo.jl
@@ -230,7 +230,7 @@ let
     function allocate_tasks_iwrite(fields::GGField...)
         if length(fields) > size(tasks,2)  # Note: for simplicity, we create a tasks for every field even if it is not an CPUField
             tasks = [tasks Array{Task}(undef, NNEIGHBORS_PER_DIM, length(fields)-size(tasks,2))];  # Create (additional) emtpy tasks.
-        end 
+        end
     end
 
     function iwrite_sendbufs!(n::Integer, dim::Integer, F::CPUField{T}, i::Integer) where T <: GGNumber  # Function to be called if A is a CPUField.
@@ -388,12 +388,12 @@ end
 function memcopy!(dst::AbstractArray{T}, src::AbstractArray{T}, use_polyester::Bool) where T <: GGNumber
     if use_polyester && nthreads() > 1 && length(src) > 1 && !(T <: Complex)  # NOTE: Polyester does not yet support Complex numbers and copy reinterpreted arrays leads to bad performance.
         memcopy_polyester!(dst, src)
-    elseif IndexStyle(dst, src) === IndexLinear()  # Both operands index linearly (e.g. the x- and z-faces): flatten and do a contiguous-stride memcopy.
+    elseif IndexStyle(dst, src) === IndexLinear()  # Both operands index linearly (e.g. the x- and z-faces): flatten + contiguous-stride memcopy.
         dst_flat = view(dst,:)
         src_flat = view(src,:)
         memcopy_threads!(dst_flat, src_flat)
-    else  # At least one operand is IndexCartesian (the middle/y-face slice view(A,:,iy,:)): flattening it with view(.,:) would force a per-element linear->Cartesian index conversion (~25-30x slower on the CPU). Copy the shaped views directly so iteration stays contiguous along the inner (fastest) dimension.
-        copyto!(dst, src)
+    else  # At least one operand is IndexCartesian, flattening would force a per-element linear->Cartesian index conversion (~25-30x slower).
+        copyto!(dst, src) # Copy the views directly so iteration stays contiguous along the inner (fastest) dimension.
     end
 end
 
@@ -423,7 +423,7 @@ function check_fields(fields::GGField...)
     elseif length(invalid_halowidths) > 0
         error("The field at position $(invalid_halowidths[1]) has a halowidth less than 1.")
     end
-    
+
     # Raise an error if any of the given fields has no halo at all (in any dimension) - in this case there is no halo update to do and including the field in the call is inconsistent.
     no_halo = Int[];
     for i = 1:length(fields)

--- a/src/update_halo.jl
+++ b/src/update_halo.jl
@@ -388,10 +388,12 @@ end
 function memcopy!(dst::AbstractArray{T}, src::AbstractArray{T}, use_polyester::Bool) where T <: GGNumber
     if use_polyester && nthreads() > 1 && length(src) > 1 && !(T <: Complex)  # NOTE: Polyester does not yet support Complex numbers and copy reinterpreted arrays leads to bad performance.
         memcopy_polyester!(dst, src)
-    else
+    elseif IndexStyle(dst, src) === IndexLinear()  # Both operands index linearly (e.g. the x- and z-faces): flatten and do a contiguous-stride memcopy.
         dst_flat = view(dst,:)
         src_flat = view(src,:)
         memcopy_threads!(dst_flat, src_flat)
+    else  # At least one operand is IndexCartesian (the middle/y-face slice view(A,:,iy,:)): flattening it with view(.,:) would force a per-element linear->Cartesian index conversion (~25-30x slower on the CPU). Copy the shaped views directly so iteration stays contiguous along the inner (fastest) dimension.
+        copyto!(dst, src)
     end
 end
 


### PR DESCRIPTION
On CPU arrays, `update_halo!` is ~25–115× slower (growing with face size) when  the **middle (y)** dimension is the decomposed one than for x or z. This PR closes https://github.com/eth-cscs/ImplicitGlobalGrid.jl/issues/123.

The issue is that `memcopy!` flattens both operands with `view(.,:)` before copying. The y-face  slice `view(A,:,iy,:)` is `IndexCartesian`, while x/z faces are `IndexLinear`. So the flat copy forces a per-element linear→Cartesian index conversion. And this is not a stride effect since the x-face is the most scattered yet fast.

The fix is to branch `memcopy!` on `IndexStyle(dst, src)`: keep the flat `view(.,:)` memcopy  for the `IndexLinear` case (x/z faces + all flat buffers), else `copyto!(dst, src)` on the shaped views so iteration stays contiguous along the inner dimension. Using the *combined* `IndexStyle(dst,src)` matters: `read_h2h!` passes the y-slice as the destination.

I have conducted the tests only on CPU backend, and I think GPU backends use a different function for this. Also I have verified this in WaterLily.jl and in the linked issue MRWE. below is the WaterLily weak scalability plot using master and this PR. In the MRWE, full `update_halo!` (np=2, Float32) results in y-face 882→26 µs (66³), 13794→120 µs (258³) with x/z unchanged. `test/test_update_halo.jl` passes 922/922.

<img height="400" alt="Image" src="https://github.com/user-attachments/assets/a21f1cdc-9410-4473-abfb-1486977b1626" />

PR and debugging assisted by Claude Opus 4.8.
